### PR TITLE
[#10] comment 로직 위임 및 컨트롤러 비지니스 로직 제거

### DIFF
--- a/src/main/java/server/comment/controller/CommentController.java
+++ b/src/main/java/server/comment/controller/CommentController.java
@@ -14,8 +14,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import server.comment.dto.CommentPostPutDto;
-import server.comment.entity.Comment;
-import server.comment.mapper.CommentMapper;
 import server.comment.service.CommentService;
 import server.jwt.oauth.PrincipalDetails;
 
@@ -25,7 +23,6 @@ import server.jwt.oauth.PrincipalDetails;
 public class CommentController {
 
     private final CommentService commentService;
-    private final CommentMapper commentMapper;
 
     @PostMapping("/answers/{answer-id}/comments")
     public ResponseEntity<Void> postComment(@Positive @PathVariable("answer-id") long answerId,
@@ -40,9 +37,7 @@ public class CommentController {
     @PutMapping("/comments/{comment-id}")
     public ResponseEntity<Void> putComment(@Positive @PathVariable("comment-id") long commentId,
                                            @Valid @RequestBody CommentPostPutDto commentPostPutDto) {
-        Comment comment = commentMapper.commentPostPutDtoToComment(commentPostPutDto);
-        comment.setCommentId(commentId);
-        commentService.updateComment(comment);
+        commentService.updateComment(commentId, commentPostPutDto);
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/server/comment/controller/CommentController.java
+++ b/src/main/java/server/comment/controller/CommentController.java
@@ -1,22 +1,26 @@
 package server.comment.controller;
 
+import java.net.URI;
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import server.answer.service.AnswerService;
 import server.comment.dto.CommentPostPutDto;
 import server.comment.entity.Comment;
 import server.comment.mapper.CommentMapper;
 import server.comment.service.CommentService;
+import server.jwt.oauth.PrincipalDetails;
 import server.user.entity.User;
 import server.user.service.UserService;
-
-import javax.validation.Valid;
-import javax.validation.constraints.Positive;
-import java.net.URI;
 
 @Validated
 @RequiredArgsConstructor
@@ -28,18 +32,13 @@ public class CommentController {
     private final AnswerService answerService;
     private final UserService userService;
 
-
     @PostMapping("/answers/{answer-id}/comments")
     public ResponseEntity<Void> postComment(@Positive @PathVariable("answer-id") long answerId,
                                             @Valid @RequestBody CommentPostPutDto commentPostPutDto,
-                                            Authentication authentication) {
-
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String email = userDetails.getUsername();
-
+                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
         Comment comment = commentMapper.commentPostPutDtoToComment(commentPostPutDto);
         comment.setAnswer(answerService.findVerifiedAnswer(answerId));
-        User user = userService.findUser(email);
+        User user = userService.findUser(principalDetails.getUsername());
         commentService.addCommentScore(user.getBadge());
         comment.setUser(user);
 
@@ -50,7 +49,7 @@ public class CommentController {
 
     @PutMapping("/comments/{comment-id}")
     public ResponseEntity<Void> putComment(@Positive @PathVariable("comment-id") long commentId,
-                                     @Valid @RequestBody CommentPostPutDto commentPostPutDto) {
+                                           @Valid @RequestBody CommentPostPutDto commentPostPutDto) {
         Comment comment = commentMapper.commentPostPutDtoToComment(commentPostPutDto);
         comment.setCommentId(commentId);
         commentService.updateComment(comment);

--- a/src/main/java/server/comment/controller/CommentController.java
+++ b/src/main/java/server/comment/controller/CommentController.java
@@ -13,14 +13,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import server.answer.service.AnswerService;
 import server.comment.dto.CommentPostPutDto;
 import server.comment.entity.Comment;
 import server.comment.mapper.CommentMapper;
 import server.comment.service.CommentService;
 import server.jwt.oauth.PrincipalDetails;
-import server.user.entity.User;
-import server.user.service.UserService;
 
 @Validated
 @RequiredArgsConstructor
@@ -29,20 +26,13 @@ public class CommentController {
 
     private final CommentService commentService;
     private final CommentMapper commentMapper;
-    private final AnswerService answerService;
-    private final UserService userService;
 
     @PostMapping("/answers/{answer-id}/comments")
     public ResponseEntity<Void> postComment(@Positive @PathVariable("answer-id") long answerId,
                                             @Valid @RequestBody CommentPostPutDto commentPostPutDto,
                                             @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Comment comment = commentMapper.commentPostPutDtoToComment(commentPostPutDto);
-        comment.setAnswer(answerService.findVerifiedAnswer(answerId));
-        User user = userService.findUser(principalDetails.getUsername());
-        commentService.addCommentScore(user.getBadge());
-        comment.setUser(user);
-
-        final Long commentId = commentService.createdComment(comment);
+        final Long commentId = commentService.createdComment(commentPostPutDto, answerId,
+                principalDetails.getUsername());
 
         return ResponseEntity.created(URI.create("/comments/" + commentId)).build();
     }

--- a/src/main/java/server/comment/dto/CommentResponseDto.java
+++ b/src/main/java/server/comment/dto/CommentResponseDto.java
@@ -1,15 +1,15 @@
 package server.comment.dto;
 
 
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 import server.user.dto.UserProfileResponseDto;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
 public class CommentResponseDto {
+
     private long commentId;
     private UserProfileResponseDto user;
     private LocalDateTime createdAt;

--- a/src/main/java/server/comment/entity/Comment.java
+++ b/src/main/java/server/comment/entity/Comment.java
@@ -11,14 +11,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import server.answer.entity.Answer;
 import server.audit.Auditable;
 import server.user.entity.User;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends Auditable {
 
@@ -38,9 +36,13 @@ public class Comment extends Auditable {
     private User user;
 
     @Builder
-    public Comment(String content, Answer answer, User user) {
+    private Comment(String content, Answer answer, User user) {
         this.content = content;
         this.answer = answer;
         this.user = user;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
     }
 }

--- a/src/main/java/server/comment/entity/Comment.java
+++ b/src/main/java/server/comment/entity/Comment.java
@@ -13,6 +13,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import server.answer.entity.Answer;
 import server.audit.Auditable;
+import server.exception.BusinessLogicException;
+import server.exception.ExceptionCode;
 import server.user.entity.User;
 
 @Entity
@@ -43,6 +45,10 @@ public class Comment extends Auditable {
     }
 
     public void updateContent(String content) {
+        if (content.isEmpty() || content.isBlank()) {
+            throw new BusinessLogicException(ExceptionCode.BLANK_CONTENT);
+        }
+
         this.content = content;
     }
 }

--- a/src/main/java/server/comment/entity/Comment.java
+++ b/src/main/java/server/comment/entity/Comment.java
@@ -1,16 +1,25 @@
 package server.comment.entity;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import server.answer.entity.Answer;
 import server.audit.Auditable;
 import server.user.entity.User;
 
-import javax.persistence.*;
-
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends Auditable {
 
     @Id
@@ -22,10 +31,16 @@ public class Comment extends Auditable {
 
     @ManyToOne
     @JoinColumn(name = "ANSWER_ID")
-     private Answer answer;
+    private Answer answer;
 
     @ManyToOne
     @JoinColumn(name = "USER_ID")
     private User user;
 
+    @Builder
+    public Comment(String content, Answer answer, User user) {
+        this.content = content;
+        this.answer = answer;
+        this.user = user;
+    }
 }

--- a/src/main/java/server/comment/mapper/CommentMapper.java
+++ b/src/main/java/server/comment/mapper/CommentMapper.java
@@ -1,19 +1,16 @@
 package server.comment.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.mapstruct.Mapper;
-import server.comment.dto.CommentPostPutDto;
 import server.comment.dto.CommentResponseDto;
 import server.comment.entity.Comment;
 import server.response.AnswerCommentUserResponseDto;
 import server.user.mapper.UserMapper;
 
-import java.util.ArrayList;
-import java.util.List;
-
 
 @Mapper(componentModel = "spring")
 public interface CommentMapper {
-    Comment commentPostPutDtoToComment(CommentPostPutDto commentPostPutDto);
 
     default CommentResponseDto commentToCommentResponseDto(Comment comment,
                                                            UserMapper userMapper) {
@@ -41,13 +38,13 @@ public interface CommentMapper {
     }
 
     default List<AnswerCommentUserResponseDto> commentsToAnswerCommentUserResponseDtos(List<Comment> comments) {
-        if ( comments == null ) {
+        if (comments == null) {
             return null;
         }
 
         List<AnswerCommentUserResponseDto> list = new ArrayList<>(comments.size());
-        for ( Comment comment : comments ) {
-            list.add( commentToAnswerCommentUserResponseDto( comment) );
+        for (Comment comment : comments) {
+            list.add(commentToAnswerCommentUserResponseDto(comment));
         }
 
         return list;

--- a/src/main/java/server/comment/repository/CommentRepository.java
+++ b/src/main/java/server/comment/repository/CommentRepository.java
@@ -13,5 +13,4 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByAnswer(Answer answer);
     Page<Comment> findAllByUser(User user, Pageable pageable);
-
 }

--- a/src/main/java/server/comment/service/CommentService.java
+++ b/src/main/java/server/comment/service/CommentService.java
@@ -1,5 +1,9 @@
 package server.comment.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,19 +23,14 @@ import server.user.entity.User;
 import server.user.mapper.UserMapper;
 import server.user.repository.BadgeRepository;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import java.util.Optional;
-
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class CommentService {
 
     private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
     private final BadgeRepository badgeRepository;
-
 
     public Long createdComment(Comment comment) {
         return commentRepository.save(comment).getCommentId();
@@ -64,7 +63,8 @@ public class CommentService {
 
     public MultiResponseDto<AnswerCommentUserResponseDto> userInfoComments(User user,
                                                                            int page, int size) {
-        Page<Comment> pageComments = commentRepository.findAllByUser(user, PageRequest.of(page-1, size, Sort.by("commentId").descending()));
+        Page<Comment> pageComments = commentRepository.findAllByUser(user,
+                PageRequest.of(page - 1, size, Sort.by("commentId").descending()));
         List<Comment> comments = pageComments.getContent();
         return new MultiResponseDto<>(commentMapper.commentsToAnswerCommentUserResponseDtos(comments), pageComments);
     }

--- a/src/main/java/server/comment/service/CommentService.java
+++ b/src/main/java/server/comment/service/CommentService.java
@@ -46,7 +46,6 @@ public class CommentService {
                 .build();
 
         commentRepository.save(comment);
-
         return comment.getCommentId();
     }
 

--- a/src/main/java/server/comment/service/CommentService.java
+++ b/src/main/java/server/comment/service/CommentService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import server.answer.entity.Answer;
+import server.answer.service.AnswerService;
 import server.comment.dto.CommentPostPutDto;
 import server.comment.dto.CommentResponseDto;
 import server.comment.entity.Comment;
@@ -33,6 +34,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
     private final UserRepository userRepository;
+    private final AnswerService answerService;
 
     public Long createdComment(CommentPostPutDto commentDto, Long answerId, String email) {
         User user = Optional.ofNullable(userRepository.findByEmail(email))
@@ -42,7 +44,7 @@ public class CommentService {
         Comment comment = Comment.builder()
                 .content(commentDto.getContent())
                 .user(user)
-                .answer(user.findAnswerByAnswerId(answerId))
+                .answer(answerService.findVerifiedAnswer(answerId))
                 .build();
 
         commentRepository.save(comment);

--- a/src/main/java/server/comment/service/CommentService.java
+++ b/src/main/java/server/comment/service/CommentService.java
@@ -37,6 +37,7 @@ public class CommentService {
     public Long createdComment(CommentPostPutDto commentDto, Long answerId, String email) {
         User user = Optional.ofNullable(userRepository.findByEmail(email))
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+        user.addBadgeScore(COMMENT_BADGE_SCORE);
 
         Comment comment = Comment.builder()
                 .content(commentDto.getContent())
@@ -44,16 +45,14 @@ public class CommentService {
                 .answer(user.findAnswerByAnswerId(answerId))
                 .build();
 
-        user.addBadgeScore(COMMENT_BADGE_SCORE);
         commentRepository.save(comment);
 
         return comment.getCommentId();
     }
 
-    public void updateComment(Comment comment) {
-        Comment findComment = findVerifiedComment(comment.getCommentId());
-        findComment.setContent(comment.getContent());
-        commentRepository.save(findComment);
+    public void updateComment(Long commentId, CommentPostPutDto commentDto) {
+        Comment comment = findVerifiedComment(commentId);
+        comment.updateContent(commentDto.getContent());
     }
 
     public void deleteComment(long commentId) {
@@ -61,9 +60,9 @@ public class CommentService {
         commentRepository.delete(findComment);
     }
 
-    public Comment findVerifiedComment(long commentId) {
-        Optional<Comment> comment = commentRepository.findById(commentId);
-        return comment.orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
+    private Comment findVerifiedComment(long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.COMMENT_NOT_FOUND));
     }
 
     public List<CommentResponseDto> findComments(Answer answer, UserMapper userMapper) {

--- a/src/main/java/server/exception/BusinessLogicException.java
+++ b/src/main/java/server/exception/BusinessLogicException.java
@@ -2,8 +2,9 @@ package server.exception;
 
 import lombok.Getter;
 
+@Getter
 public class BusinessLogicException extends RuntimeException {
-    @Getter
+
     private final ExceptionCode exceptionCode;
 
     public BusinessLogicException(ExceptionCode exceptionCode) {

--- a/src/main/java/server/exception/ExceptionCode.java
+++ b/src/main/java/server/exception/ExceptionCode.java
@@ -2,7 +2,9 @@ package server.exception;
 
 import lombok.Getter;
 
+@Getter
 public enum ExceptionCode {
+
     ACCESS_TOKEN_EXPIRED(401, "ACCESS TOKEN EXPIRED"),
     REFRESH_TOKEN_EXPIRED(401, "REFRESH TOKEN EXPIRED"),
     INVALID_REFRESH_TOKEN(400, "INVALID REFRESH TOKEN"),
@@ -17,14 +19,11 @@ public enum ExceptionCode {
     INVALID_SORT_PARAMETER(400, "INVALID SORT PARAMETER"),
     DUPLICATE_VOTE(400, "DUPLICATE VOTE"),
     INVALID_USER(401, "유효하지 않은 유저정보입니다."),
-    UNAUTHORIZED_USER(403,"권한이 없습니다."),
-    UNAUTHENTICATED_USER(403,"로그인이 필요합니다.");
+    UNAUTHORIZED_USER(403, "권한이 없습니다."),
+    UNAUTHENTICATED_USER(403, "로그인이 필요합니다."),
+    BLANK_CONTENT(400, "CONTENT IS BLANK");
 
-
-    @Getter
     private final int status;
-
-    @Getter
     private final String message;
 
     ExceptionCode(int status, String message) {

--- a/src/main/java/server/user/entity/Badge.java
+++ b/src/main/java/server/user/entity/Badge.java
@@ -1,8 +1,17 @@
 package server.user.entity;
 
-import lombok.*;
-
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -27,10 +36,14 @@ public class Badge {
     private User user;
 
     @Builder
-    public Badge(int score, int level, String badgeImg,User user) {
+    public Badge(int score, int level, String badgeImg, User user) {
         this.score = score;
         this.level = level;
         this.badgeImg = badgeImg;
         this.user = user;
+    }
+
+    public void addScore(int addValue) {
+        this.score += addValue;
     }
 }

--- a/src/main/java/server/user/entity/User.java
+++ b/src/main/java/server/user/entity/User.java
@@ -6,6 +6,8 @@ import server.answer.entity.Answer;
 
 import server.audit.Auditable;
 import server.comment.entity.Comment;
+import server.exception.BusinessLogicException;
+import server.exception.ExceptionCode;
 import server.question.entity.Question;
 
 import javax.persistence.*;
@@ -61,5 +63,16 @@ public class User extends Auditable {
         UserStatus(String status) {
             this.status = status;
         }
+    }
+
+    public Answer findAnswerByAnswerId(Long answerId) {
+        return answers.stream()
+                .filter(answer -> answerId.equals(answer.getAnswerId()))
+                .findAny()
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND));
+    }
+
+    public void addBadgeScore(int addValue) {
+        this.badge.addScore(addValue);
     }
 }

--- a/src/main/java/server/user/entity/User.java
+++ b/src/main/java/server/user/entity/User.java
@@ -106,13 +106,6 @@ public class User extends Auditable {
         userStatus = status;
     }
 
-    public Answer findAnswerByAnswerId(Long answerId) {
-        return answers.stream()
-                .filter(answer -> answerId.equals(answer.getAnswerId()))
-                .findAny()
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND));
-    }
-
     public void addBadgeScore(int addValue) {
         this.badge.addScore(addValue);
     }

--- a/src/main/java/server/user/entity/User.java
+++ b/src/main/java/server/user/entity/User.java
@@ -1,7 +1,25 @@
 package server.user.entity;
 
+import static server.user.entity.User.UserStatus.USER_ACTIVE;
+import static server.user.entity.User.UserStatus.USER_QUIT;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import server.answer.entity.Answer;
 import server.audit.Auditable;
 import server.comment.entity.Comment;
@@ -9,16 +27,10 @@ import server.exception.BusinessLogicException;
 import server.exception.ExceptionCode;
 import server.question.entity.Question;
 
-import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
-
-import static server.user.entity.User.UserStatus.USER_ACTIVE;
-import static server.user.entity.User.UserStatus.USER_QUIT;
-
 @Entity
 @Getter
 @Table(name = "USER_TABLE")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -64,16 +76,6 @@ public class User extends Auditable {
         }
     }
 
-    public Answer findAnswerByAnswerId(Long answerId) {
-        return answers.stream()
-                .filter(answer -> answerId.equals(answer.getAnswerId()))
-                .findAny()
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND));
-    }
-
-    public void addBadgeScore(int addValue) {
-        this.badge.addScore(addValue);
-
     @Builder
     public User(String password, String email, String nickname) {
         this.password = password;
@@ -102,5 +104,16 @@ public class User extends Auditable {
 
     public void updateStatus(UserStatus status) {
         userStatus = status;
+    }
+
+    public Answer findAnswerByAnswerId(Long answerId) {
+        return answers.stream()
+                .filter(answer -> answerId.equals(answer.getAnswerId()))
+                .findAny()
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.ANSWER_NOT_FOUND));
+    }
+
+    public void addBadgeScore(int addValue) {
+        this.badge.addScore(addValue);
     }
 }


### PR DESCRIPTION
## 연관 이슈
- close #10 

## 작업 요약
- CommentController 내 비지니스 로직 제거하고, Service와 도메인에 로직이 위치하도록 했습니다.
- CommentService의 findComments(), userInfoComments() 는 리팩토링을 수행하지 않았습니다. Mapper 가 복잡하게 얽혀있어서, Mapper에 대한 논의가 끝난 후에 리팩토링 하는 편이 좋을 것 같아서요.

## 기타 논의하고 싶은 내용
- 현재 도메인 <-> DTO 변환을 위해 MapStruct를 사용하고 있는데, 계속 사용할지에 대해 논의해봐야 할 것 같아요. 직접 Mapper를 구현했을 때와의 장단점을 비교해보고 걷어내던지 리팩토링 하던지 정해보죠.
